### PR TITLE
Update onboarding.php

### DIFF
--- a/onboarding.php
+++ b/onboarding.php
@@ -36,11 +36,11 @@ class OnBoarding extends Module
 		$this->tab = 'administration';
 		$this->version = '0.1.5';
 		$this->author = 'PrestaShop';
-		$this->displayName = $this->l('OnBoarding');
-		$this->description = $this->l('The OnBoarding module greets first-time users to their PrestaShop back-office: through a small playful
-			interface, it shows the user how to launch his/her shop in several easy steps.');
 
 		parent::__construct();
+
+		$this->displayName = $this->l('OnBoarding');
+		$this->description = $this->l('The OnBoarding module greets first-time users to their PrestaShop back-office: through a small playful interface, it shows the user how to launch his/her shop in several easy steps.');
 
 		if (Configuration::get('PS_ONBOARDING_CURRENT_STEP') > 6)
 			$this->uninstall();


### PR DESCRIPTION
1. $this->displayName and $this->description should be after parent::__construct();
2. translation strings not accepted breaklines inside. If yes, they can't be translated.

3. BUG: When module is translated into other language, the translated strings are dissapear. Please check the screenshot: http://imageshack.com/a/img537/3043/padYZ5.png